### PR TITLE
Changed `codeception` to `site5` in README explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Phantoman is available via [Composer](https://getcomposer.org). Add the
 following to the `require` section of your project's `composer.json` file.
 
 ```
-"codeception/phantoman": "1.*"
+"site5/phantoman": "1.*"
 ```
 
 Then run `composer update` and `composer install` to complete the installation


### PR DESCRIPTION
Ah, I realized it's just the wrong repository name in the README. Pull request addresses #5 .
