### PR TITLE
Update composer install instructions to use require

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@ and stopping [PhantomJS](http://phantomjs.org/) when running tests.
 - Codeception 1.6.4
 - PHP 5.4
 
-## Installation
+## Installation using [Composer](https://getcomposer.org)
 
-Phantoman is available via [Composer](https://getcomposer.org). Add the
-following to the `require` section of your project's `composer.json` file.
-
+```bash
+$ composer require site5/phantoman
 ```
-"site5/phantoman": "~1.0"
-```
-
-Then run `composer update` and `composer install` to complete the installation
-process.
 
 Be sure to enable the extension in `codeception.yml` as shown in
 [configuration](#configuration) below.
@@ -101,7 +95,7 @@ Once installed and enabled, running your tests with `php codecept run` will
 automatically start the PhantomJS server and wait for it to be accessible before
 proceeding with the tests.
 
-```
+```bash
 Starting PhantomJS Server
 Waiting for the PhantomJS server to be reachable..
 PhantomJS server now accessible
@@ -109,6 +103,6 @@ PhantomJS server now accessible
 
 Once the tests are complete, PhantomJS will be shut down.
 
-```
+```bash
 Stopping PhantomJS Server
 ```


### PR DESCRIPTION
It's recommended that `composer require` be used for installing dependencies instead of manually altering the `composer.json` file.

Installation steps are now much simpler, only the one require step, instead of requiring people to run `composer update` and `composer install` manually.

This came up in [a discussion](https://github.com/KnpLabs/snappy/pull/118#discussion_r20793023) in another project and I figured it would be good to adjust here as well.
