### PR TITLE
Added gitattributes file to ignore unneeded files when distributing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This is another "best practice" PR.

This adds `.gitattributes` which is set up to ignore certain files when an export is created. [Packagist](https://packagist.org/) works by getting the latest `.zip` from Github. The use of git attributes results in a smaller download be excluding unneeded files and folders.

In practice, this isn't much of a gain for Phantoman right now but it's a good standard to adhere to. It comes more into play when you have large tests and documentation folders for a project. 
