### PR TITLE
Add windows .exe extension to the path

### DIFF
--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -34,11 +34,6 @@ class Phantoman extends \Codeception\Platform\Extension
             $this->config['path'] = "vendor/bin/phantomjs";
         }
 
-        // Add .exe extension if running on the windows
-        if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
-            $this->config['path'] .= '.exe';
-        }
-
         // If a directory was provided for the path, use old method of appending PhantomJS
         if (is_dir(realpath($this->config['path']))) {
             // Show warning that this is being deprecated
@@ -46,6 +41,11 @@ class Phantoman extends \Codeception\Platform\Extension
             $this->writeLn("WARNING: The PhantomJS path for Phantoman is set to a directory, this is being deprecated in the future. Please update your Phantoman configuration to be the full path to PhantomJS.");
 
             $this->config['path'] .= '/phantomjs';
+        }
+
+        // Add .exe extension if running on the windows
+        if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
+            $this->config['path'] .= '.exe';
         }
 
         // Set default WebDriver port

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -34,6 +34,11 @@ class Phantoman extends \Codeception\Platform\Extension
             $this->config['path'] = "vendor/bin/phantomjs";
         }
 
+        // Add .exe extension if running on the windows
+        if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
+            $this->config['path'] .= '.exe';
+        }
+
         // If a directory was provided for the path, use old method of appending PhantomJS
         if (is_dir(realpath($this->config['path']))) {
             // Show warning that this is being deprecated
@@ -191,6 +196,17 @@ class Phantoman extends \Codeception\Platform\Extension
     private function getCommand()
     {
         return escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
+    }
+
+    /**
+     * Checks if the current machine is Windows.
+     *
+     * @return bool True if the machine is windows.
+     * @see http://stackoverflow.com/questions/5879043/php-script-detect-whether-running-under-linux-or-windows
+     */
+    private function isWindows()
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
     }
 
     // methods that handle events


### PR DESCRIPTION
When running on the windows machine the binary file is called `phantomjs.exe` by default.
The **.exe** extension should be added to the path.

Refs #16