### PR TITLE
Add support for the 'ignore-ssl-errors' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ options are listed below.
 
 - `webSecurity: {true|false}`
     - Enables web security
+- `ignoreSslErrors: {true|false}`
+    - Ignores errors in the SSL validation.
 
 ## Usage
 

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -185,6 +185,10 @@ class Phantoman extends \Codeception\Platform\Extension
         $params = array();
         foreach ($this->config as $configKey => $configValue) {
             if (!empty($mapping[$configKey])) {
+                if (is_bool($configValue)) {
+                    // Make sure the value is true/false and not 1/0
+                    $configValue = ($configValue) ? 'true' : 'false';
+                }
                 $params[] = $mapping[$configKey] . '=' . $configValue;
             }
         }

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -180,6 +180,7 @@ class Phantoman extends \Codeception\Platform\Extension
             'proxyAuth' => '--proxy-auth',
             'webSecurity' => '--web-security',
             'port' => '--webdriver',
+            'ignoreSslErrors' => '--ignore-ssl-errors',
         );
         $params = array();
         foreach ($this->config as $configKey => $configValue) {


### PR DESCRIPTION
I needed this to test a website that uses a self-signed certificate.