### PR TITLE
Added debug option and command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ options are listed below.
 - `port: {port}`
     - Webdriver port to start PhantomJS with.
     - Default: `4444`
+- `debug: {true|false}`
+    - Display debug output while Phantoman runs
+    - Default: `false`
 
 #### Proxy Support
 
@@ -92,7 +95,7 @@ options are listed below.
     - Enables web security
 - `ignoreSslErrors: {true|false}`
     - Ignores errors in the SSL validation.
-- `sslProtocol: [sslv3|sslv2|tlsv1|any]`
+- `sslProtocol: {sslv3|sslv2|tlsv1|any}`
     - Sets the SSL protocol for secure connections (default is `SSLv3`).
 - `remoteDebuggerPort: {port}`
     - Starts PhantomJS in a debug harness and listens on the specified port

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -37,8 +37,8 @@ class Phantoman extends \Codeception\Platform\Extension
         // If a directory was provided for the path, use old method of appending PhantomJS
         if (is_dir(realpath($this->config['path']))) {
             // Show warning that this is being deprecated
-            $this->writeLn("\r\n");
-            $this->writeLn("WARNING: The PhantomJS path for Phantoman is set to a directory, this is being deprecated in the future. Please update your Phantoman configuration to be the full path to PhantomJS.");
+            $this->writeln("\r\n");
+            $this->writeln("WARNING: The PhantomJS path for Phantoman is set to a directory, this is being deprecated in the future. Please update your Phantoman configuration to be the full path to PhantomJS.");
 
             $this->config['path'] .= '/phantomjs';
         }
@@ -51,6 +51,11 @@ class Phantoman extends \Codeception\Platform\Extension
         // Set default WebDriver port
         if (!isset($this->config['port'])) {
             $this->config['port'] = 4444;
+        }
+
+        // Set default debug mode
+        if (!isset($this->config['debug'])) {
+            $this->config['debug'] = false;
         }
 
         $this->startServer();
@@ -79,11 +84,21 @@ class Phantoman extends \Codeception\Platform\Extension
             return;
         }
 
-        $this->writeLn("\r\n");
+        $this->writeln("\r\n");
         $this->writeln("Starting PhantomJS Server");
 
         $command = $this->getCommand();
-        
+
+        if ($this->config['debug']) {
+            $this->writeln("\r\n");
+
+            // Output the generated command
+            $this->writeln('Generated PhantomJS Command:');
+            $this->writeln($command);
+
+            $this->writeln("\r\n");
+        }
+
         $descriptorSpec = array(
             array('pipe', 'r'),
             array('file', $this->getLogDir() . 'phantomjs.output.txt', 'w'),
@@ -100,7 +115,7 @@ class Phantoman extends \Codeception\Platform\Extension
         // Wait till the server is reachable before continuing
         $max_checks = 10;
         $checks = 0;
-        
+
         $this->write("Waiting for the PhantomJS server to be reachable");
         while (true) {
             if ($checks >= $max_checks) {


### PR DESCRIPTION
As part of the debug output, when enabled, Phantoman will output the
generated PhantomJS command that is used for the test run.

This was initial brought up in PR #29.

### Output

```
Starting PhantomJS Server


Generated PhantomJS Command:
'vendor/bin/phantomjs' --webdriver=4444


Waiting for the PhantomJS server to be reachable..
PhantomJS server now accessible
```