### PR TITLE
Adjust use statement to use correct ExtensionException class

### DIFF
--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -11,7 +11,7 @@
 
 namespace Codeception\Extension;
 
-use Codeception\Exception\Extension as ExtensionException;
+use Codeception\Exception\ExtensionException;
 
 class Phantoman extends \Codeception\Platform\Extension
 {


### PR DESCRIPTION
The use statement tries to import the `Codeception\Exception\Extension` class but it is named `Codeception\Exception\ExtensionException` in the current codeception version.