### PR TITLE
Set minimum Codeception version to 2.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "codeception/codeception": ">=1.6.4"
+        "codeception/codeception": "~2.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
After researching what actual minimum Codception version could be used,
we've always been using `getLogDir` in the script which is a 2.0 feature
and thus Phantoman's always been limited to Codeception 2.0.