### PR TITLE
Updated use statement for the Extension Exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "codeception/codeception": "~2.0.0"
+        "codeception/codeception": "~2.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -11,7 +11,7 @@
 
 namespace Codeception\Extension;
 
-use Codeception\Exception\Extension as ExtensionException;
+use Codeception\Exception\ExtensionException;
 
 class Phantoman extends \Codeception\Platform\Extension
 {


### PR DESCRIPTION
Thanks to @sascha-egerer for the original PR #33.

This updates Phantoman for compatibility with Codeception 2.1.x which changed around come exception class names.

This bumps the minimum Codeception version requirement to `2.1.x`