### PR TITLE
Prefix phantomjs start command with "exec" on non Windows system 

### DIFF
--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -217,7 +217,10 @@ class Phantoman extends \Codeception\Platform\Extension
      */
     private function getCommand()
     {
-        return escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
+        // Prefix command with exec on non Windows systems to ensure that we receive the correct pid.
+        // See http://php.net/manual/en/function.proc-get-status.php#93382
+        $commandPrefix = $this->isWindows() ? '' : 'exec ';
+        return escapeshellarg($commandPrefix . realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
     }
 
     /**

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -220,7 +220,7 @@ class Phantoman extends \Codeception\Platform\Extension
         // Prefix command with exec on non Windows systems to ensure that we receive the correct pid.
         // See http://php.net/manual/en/function.proc-get-status.php#93382
         $commandPrefix = $this->isWindows() ? '' : 'exec ';
-        return escapeshellarg($commandPrefix . realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
+        return $commandPrefix . escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
     }
 
     /**


### PR DESCRIPTION
… to ensure that we don't spawn child processes with a separate pid.

This aims to mitigrate #20 till the other todos are done.