### PR TITLE
Added the rest of the PhantomJS CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,41 @@ options are listed below.
     - Enables web security
 - `ignoreSslErrors: {true|false}`
     - Ignores errors in the SSL validation.
+    - Defaults to `false`
 - `sslProtocol: {sslv3|sslv2|tlsv1|any}`
-    - Sets the SSL protocol for secure connections (default is `SSLv3`).
+    - Sets the SSL protocol for secure connections
+    - Defaults to `sslv3`
+- `sslCertificatesPath: {path}`
+    - Sets the location for custom CA certificates (if none set, uses system
+      default).
 - `remoteDebuggerPort: {port}`
     - Starts PhantomJS in a debug harness and listens on the specified port
+- `remoteDebuggerAutorun: {true|false}`
+    - Runs the script in the debugger immediately
+    - Defaults to `false`
+- `cookiesFile: {file path}`
+    - Sets the file name to store the persistent cookies
+- `diskCache: {true|false}`
+    - Enabled disk cache
+    - Defaults to `false`
+- `maxDiskCacheSize: {number}`
+    - Limit the size of the disk cache in KB
+- `loadImages: {true|false}`
+    - Loads all inlined images
+    - Defaults to `true`
+- `localStoragePath: {file path}`
+    - The path to save LocalStorage content and WebSQL content
+- `localStorageQuota: {number}`
+    - Maximum size to allow for data in local storage in KB
+- `localToRemoteUrlAccess: {true|false}`
+    - Allows local content to access remote URL
+    - Defaults to `false`
+- `outputEncoding: {encoding}`
+    - Sets the encoding for the terminal output
+    - Default is `utf8`
+- `scriptEncoding: {encoding}`
+    - Sets the encoding used for starting the script
+    - Default is `utf8`
 
 ## Usage
 

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -189,17 +189,29 @@ class Phantoman extends \Codeception\Platform\Extension
      */
     private function getCommandParameters()
     {
+        // Map our config options to PhantomJS options
         $mapping = array(
-            'cookiesFile' => '--cookies-file',
+            'port' => '--webdriver',
             'proxy' => '--proxy',
             'proxyType' => '--proxy-type',
             'proxyAuth' => '--proxy-auth',
             'webSecurity' => '--web-security',
-            'port' => '--webdriver',
             'ignoreSslErrors' => '--ignore-ssl-errors',
             'sslProtocol' => '--ssl-protocol',
-            'remoteDebuggerPort' => '--remote-debugger-port'
+            'sslCertificatesPath' => '--ssl-certificates-path',
+            'remoteDebuggerPort' => '--remote-debugger-port',
+            'remoteDebuggerAutorun' => '--remote-debugger-autorun',
+            'cookiesFile' => '--cookies-file',
+            'diskCache' => '--disk-cache',
+            'maxDiskCacheSize' => '--max-disk-cache-size',
+            'loadImage' => '--load-images',
+            'localStoragePath' => '--local-storage-path',
+            'localStorageQuota' => '--local-storage-quota',
+            'localToRemoteUrlAccess' => '--local-to-remote-url-access',
+            'outputEncoding' => '--output-encoding',
+            'scriptEncoding' => '--script-encoding',
         );
+
         $params = array();
         foreach ($this->config as $configKey => $configValue) {
             if (!empty($mapping[$configKey])) {
@@ -210,6 +222,7 @@ class Phantoman extends \Codeception\Platform\Extension
                 $params[] = $mapping[$configKey] . '=' . $configValue;
             }
         }
+
         return implode(' ', $params);
     }
 


### PR DESCRIPTION
Previously we only had a few of the PhantomJS options supported and we'd
have PRs come in to add more. Instead of adding them one a time, this PR
adds the rest that weren't there before.