### PR TITLE
A solution for only starting phantomjs for particular suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ options are listed below.
 
 - `suites: {array|string}`
     - If omitted PhantomJS is started for all suites otherwise specify an array of suites
-      or a single suite name.
+      or a single suite name. If using an environment (--env) then codeception appends the environment
+      name to the suite name in brackets e.g. "acceptance (staging)". You need to include each suite/environment
+      combination separately in the array.
     - Defaults to all suites
 - `webSecurity: {true|false}`
     - Enables web security

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ extensions:
         Codeception\Extension\Phantoman:
             path: '/usr/bin/phantomjs'
             port: 4445
+            suites: ['acceptance']
 ```
 
 ### Available options
@@ -91,6 +92,10 @@ options are listed below.
 
 #### Other
 
+- `suites: {array|string}`
+    - If omitted PhantomJS is started for all suites otherwise specify an array of suites
+      or a single suite name.
+    - Defaults to all suites
 - `webSecurity: {true|false}`
     - Enables web security
 - `ignoreSslErrors: {true|false}`

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -263,14 +263,5 @@ class Phantoman extends \Codeception\Platform\Extension
         }
 
         $this->startServer();
-
-        $resource = $this->resource;
-        register_shutdown_function(
-            function () use ($resource) {
-                if (is_resource($resource)) {
-                    proc_terminate($resource);
-                }
-            }
-        );
     }
 }

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -45,7 +45,7 @@ class Phantoman extends \Codeception\Platform\Extension
         }
 
         // Add .exe extension if running on the windows
-        if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
+        if ($this->isWindows()) {
             $this->config['path'] .= '.exe';
         }
 
@@ -224,7 +224,7 @@ class Phantoman extends \Codeception\Platform\Extension
         // Prefix command with exec on non Windows systems to ensure that we receive the correct pid.
         // See http://php.net/manual/en/function.proc-get-status.php#93382
         $commandPrefix = $this->isWindows() ? '' : 'exec ';
-        return $commandPrefix . escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
+        return $commandPrefix . escapeshellarg($this->config['path']) . ' ' . $this->getCommandParameters();
     }
 
     /**


### PR DESCRIPTION
A solution for only starting phantomjs for particular suites as discussed in other issues. e.g. Issue #3  

This solution add a 'suites' configuration option to which you can leave out (all suites), pass a string (single suite) or an array of suite names (multiple suites).

e.g.:

```yml
extensions:
    enabled:
        - Codeception\Extension\Phantoman
    config:
          Codeception\Extension\Phantoman:
              path: '/usr/bin/phantomjs'
              suites: ['acceptance']
```