### PR TITLE
Allow Phantoman to only start for specific suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ extensions:
         Codeception\Extension\Phantoman:
             path: '/usr/bin/phantomjs'
             port: 4445
+            suites: ['acceptance']
 ```
 
 ### Available options
@@ -91,6 +92,13 @@ options are listed below.
 
 #### Other
 
+- `suites: {array|string}`
+    - If omitted, PhantomJS is started for all suites.
+    - Specify an array of suites or a single suite name.
+        - If you're using an environment (`--env`), Codeception appends the
+          environment name to the suite name in brackets. You need to include
+          each suite/environment combination separately in the array.
+            - `suites: ['acceptance', 'acceptance (staging)', 'acceptance (prod)']`
 - `webSecurity: {true|false}`
     - Enables web security
 - `ignoreSslErrors: {true|false}`


### PR DESCRIPTION
This adds the `suites` configuration ability which allows one to set what suites to start PhantomJS for.

If **any** of the current suites being run match any of the desired suites, PhantomJS is started for the **entire** test run and is stopped after the last suite.

Suite configuration can either be a single string or an array of values.

Many thanks to @acuthbert for initially getting this started.

This PR replaces #40 as some work was needed to get it fully working. The core functionality should still be the same.

This PR should resolve Issue #3.