### PR TITLE
Added a silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ options are listed below.
 - `scriptEncoding: {encoding}`
     - Sets the encoding used for starting the script
     - Default is `utf8`
+- `silent: {true|false}`
+    - Suppresses messages about starting and stopping the server
+    - Default is `false`
 
 ## Usage
 

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -26,6 +26,15 @@ class Phantoman extends \Codeception\Platform\Extension
 
     public function __construct($config, $options)
     {
+        // Codeception has an option called silent, which suppresses the console output.
+        // Unfortunately there is no builtin way to activate this mode for a single extension.
+        // This is why the option will passed from the extension configuration ($config)
+        // to the global configuration ($options);
+        // Note: This must be done before calling the parent constructor.
+        if (isset($config['silent']) && $config['silent']) {
+            $options['silent'] = true;
+        }
+
         parent::__construct($config, $options);
 
         // Set default path for PhantomJS to "vendor/bin/phantomjs" for if it was installed via composer


### PR DESCRIPTION
Hi,

I'd like to have a option that suppresses the messages about starting and stopping the server. Thanks to @grantlucas I know that there is a Codeception option called "silent" which can be set globally via the settings, but unfortunately not for a specific extension. So I've wrote a little workaround for this. For me this is not a clean solution, but on the other hand the output methods remain untouched.

Hint: I've tested if this also effects other extensions and it doesn't.


Alex