### PR TITLE
Changed SIGINT back to 2

### DIFF
--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -169,7 +169,7 @@ class Phantoman extends \Codeception\Platform\Extension
                 foreach ($this->pipes as $pipe) {
                     fclose($pipe);
                 }
-                proc_terminate($this->resource, SIGINT);
+                proc_terminate($this->resource, 2);
 
                 $this->write('.');
 


### PR DESCRIPTION
The use of SIGINT adds the dependency of the PCNTL extension

Since this worked before with the integer, there's no need to add the
requirement of the PCNTL extension for a single constant.